### PR TITLE
Handle array out of bounds in mul()

### DIFF
--- a/Z.js
+++ b/Z.js
@@ -115,7 +115,7 @@ export class Z {
 		// Put every digit back into the range [0, 2^25)
 		var carry = 0;
 		for(var i = 0; i < this.length; i++) {
-			var digit = this._digits[i] + carry;
+			var digit = (this._digits[i]||0) + carry;
 			carry = Math.floor(digit / Z._innerBase);
 			this._digits[i] = (digit % Z._innerBase + Z._innerBase) % Z._innerBase;
 		}
@@ -177,7 +177,7 @@ export class Z {
 			for(var thatIndex = 1; thatIndex < thatLength; thatIndex++) {
 				var thatDigit = that._digits[thatIndex];
 				for(var thisIndex = 0; thisIndex < thisLength; thisIndex++) {
-					this._digits[thisIndex+thatIndex] = (this._digits[thisIndex+thatIndex]||0) + thisDigits[thisIndex] * thatDigit;
+					this._digits[thisIndex+thatIndex] = (this._digits[thisIndex+thatIndex]||0) + (thisDigits[thisIndex]||0) * thatDigit;
 				}
 				// I have enough wiggle room that 6 or 7 additions can be done without normalizing.
 				if(thatIndex%6 == 0) this._normalize();


### PR DESCRIPTION
Minimal bug test case:

```js
(new Z(1)).mul(new Z(2).pow(175))._digits
```

Returns a list of NaN, which should be instead the following: `[ 0, 0, 0, 0, 0, 0, 0, 1 ]`.

This commit fixes the problematic behavior.

Fixes #8.